### PR TITLE
Minor optimizations to job searcher/analyzer

### DIFF
--- a/backend/src/constants.js
+++ b/backend/src/constants.js
@@ -1,3 +1,3 @@
 export const JOBS_PER_SEND = 20;
-export const MIN_JOBS_IN_DB = 200;
+export const MIN_JOBS_IN_DB = 500;
 export const MEDIA_ROOT = 'mediafiles/';

--- a/backend/src/job_analyzer/JobAnalyzer.js
+++ b/backend/src/job_analyzer/JobAnalyzer.js
@@ -25,25 +25,23 @@ class JobAnalyzer {
 
     await forEachAsync(skills, async (skill) => {
       let docCount = 0;
-      const wordCount = [];
       const keywordCount = [];
       const keyword = skill.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
       const re = new RegExp(keyword, 'g');
 
       jobs.forEach((posting) => {
-        const count = (posting.description.toString().match(re) || []).length;
-        wordCount.push(posting.description.split(' ').length);
+        const count = (posting.description.toLowerCase().match(re) || []).length;
         keywordCount.push(count);
         if (count > 0) {
           docCount += 1;
         }
       });
 
-      let postingIdx = 0;
       const jobsLen = jobs.length;
       // calculate tf_idf each doc and save it
       await forEachAsync(jobs, async (job, i) => {
-        const tf = keywordCount[postingIdx] / wordCount[postingIdx];
+        const wordCount = job.description.split(' ').length;
+        const tf = keywordCount[i] / wordCount;
         const idf = docCount !== 0 ? Math.log(jobsLen / docCount) : 0;
         const tfidf = tf * idf;
 
@@ -60,7 +58,6 @@ class JobAnalyzer {
         }
 
         await job.save();
-        postingIdx += 1;
       });
     });
 


### PR DESCRIPTION
When we have an array of `Promises` to resolve, each that take a non-trivial amount of time, if we do not care about the ordering of the results, we can use `Promises.all` to execute all the async functions in parallel (i.e. all functions are launched one after another without waiting for previous ones to finish).

If we do care about ordering, we should use `forEachAsync` instead. This will block subsequent functions from launching until previous ones are complete.